### PR TITLE
Set test config defaults to remove warnings

### DIFF
--- a/tests/bad_configuration0
+++ b/tests/bad_configuration0
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,8 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.01
+enabled_default           = True
+enabled_mutate_rate       = 0.01
+enabled_rate_to_true_add  = 0.0
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = full
@@ -51,15 +55,21 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
 response_mutate_rate    = 0.0
 response_replace_rate   = 0.0
 
+# structural mutation
+single_structural_mutation = False
+structural_mutation_surer = default
+
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/bad_configuration1
+++ b/tests/bad_configuration1
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,11 +19,16 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
 bias_mutate_rate        = 0.7
 bias_replace_rate       = 0.1
+
+# structural mutation
+single_structural_mutation = False
+structural_mutation_surer = default
 
 # genome compatibility options
 compatibility_disjoint_coefficient = 1.0
@@ -33,8 +39,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.01
+enabled_default          = True
+enabled_mutate_rate      = 0.01
+enabled_rate_to_false_add = 0.0
+enabled_rate_to_true_add  = 0.0
 
 feed_forward            = True
 initial_connection      = full
@@ -51,6 +59,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
@@ -60,6 +69,7 @@ response_replace_rate   = 0.0
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5
@@ -72,8 +82,10 @@ compatibility_threshold = 3.0
 [DefaultStagnation]
 species_fitness_func = max
 max_stagnation       = 20
+species_elitism      = 0
 
 [DefaultReproduction]
 elitism            = 2
 survival_threshold = 0.2
+min_species_size   = 1
 

--- a/tests/bad_configuration2
+++ b/tests/bad_configuration2
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,8 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.01
+enabled_default           = True
+enabled_mutate_rate       = 0.01
+enabled_rate_to_true_add  = 0.0
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = full
@@ -51,15 +55,21 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
 response_mutate_rate    = 0.0
 response_replace_rate   = 0.0
 
+# structural mutation
+single_structural_mutation = False
+structural_mutation_surer = default
+
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/bad_configuration3
+++ b/tests/bad_configuration3
@@ -4,6 +4,7 @@ fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
 bad_config_item = True
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -19,6 +20,7 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -34,8 +36,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.01
+enabled_default           = True
+enabled_mutate_rate       = 0.01
+enabled_rate_to_true_add  = 0.0
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = full
@@ -52,6 +56,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
@@ -61,6 +66,7 @@ response_replace_rate   = 0.0
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/bad_configuration4
+++ b/tests/bad_configuration4
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,8 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.01
+enabled_default           = True
+enabled_mutate_rate       = 0.01
+enabled_rate_to_true_add  = 0.0
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = partial 1.5
@@ -51,15 +55,21 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
 response_mutate_rate    = 0.0
 response_replace_rate   = 0.0
 
+# structural mutation
+single_structural_mutation = False
+structural_mutation_surer = default
+
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/bad_configuration5
+++ b/tests/bad_configuration5
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = True
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum product max min maxabs median mean
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,9 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.05
-enabled_rate_to_true_add = 0.5
+enabled_default           = True
+enabled_mutate_rate       = 0.05
+enabled_rate_to_true_add  = 0.5
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = partial 0.5
@@ -52,6 +55,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0

--- a/tests/bad_configuration6
+++ b/tests/bad_configuration6
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = True
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum product max min maxabs median mean
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -52,6 +54,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0

--- a/tests/bad_configuration7
+++ b/tests/bad_configuration7
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -51,6 +53,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
@@ -60,6 +63,7 @@ response_replace_rate   = 0.0
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/bad_configuration8
+++ b/tests/bad_configuration8
@@ -14,6 +14,7 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -47,6 +48,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
@@ -56,6 +58,7 @@ response_replace_rate   = 0.0
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/bad_configuration9
+++ b/tests/bad_configuration9
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = True
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum product max min maxabs median mean
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,9 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.05
-enabled_rate_to_true_add = 0.5
+enabled_default           = True
+enabled_mutate_rate       = 0.05
+enabled_rate_to_true_add  = 0.5
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = partial 0.5
@@ -52,6 +55,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0

--- a/tests/bad_configurationA
+++ b/tests/bad_configurationA
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,11 +19,16 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
 bias_mutate_rate        = 0.7
 bias_replace_rate       = 0.1
+
+# structural mutation
+single_structural_mutation = False
+structural_mutation_surer = default
 
 # genome compatibility options
 compatibility_disjoint_coefficient = 1.0
@@ -35,6 +41,8 @@ conn_delete_prob        = 0.5
 # connection enable options
 enabled_default         = bad_value
 enabled_mutate_rate     = 0.01
+enabled_rate_to_false_add = 0.0
+enabled_rate_to_true_add  = 0.0
 
 feed_forward            = True
 initial_connection      = full
@@ -51,6 +59,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
@@ -60,6 +69,7 @@ response_replace_rate   = 0.0
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/test_configuration
+++ b/tests/test_configuration
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,8 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.01
+enabled_default           = True
+enabled_mutate_rate       = 0.01
+enabled_rate_to_true_add  = 0.0
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = full
@@ -51,15 +55,21 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
 response_mutate_rate    = 0.0
 response_replace_rate   = 0.0
 
+# structural mutation
+single_structural_mutation = False
+structural_mutation_surer = default
+
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 1.0
+weight_init_type        = gaussian
 weight_max_value        = 30
 weight_min_value        = -30
 weight_mutate_power     = 0.5

--- a/tests/test_configuration2
+++ b/tests/test_configuration2
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = True
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum product max min maxabs median mean
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,9 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.05
-enabled_rate_to_true_add = 0.5
+enabled_default           = True
+enabled_mutate_rate       = 0.05
+enabled_rate_to_true_add  = 0.5
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = partial 0.5
@@ -52,6 +55,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0
@@ -60,6 +64,7 @@ response_replace_rate   = 0.0
 
 # structural mutation
 single_structural_mutation = True
+structural_mutation_surer = default
 
 # connection weight options
 weight_init_mean        = 0.0

--- a/tests/test_configuration3
+++ b/tests/test_configuration3
@@ -3,6 +3,7 @@ fitness_criterion     = max
 fitness_threshold     = 0.9
 pop_size              = 150
 reset_on_extinction   = True
+no_fitness_termination = False
 
 [DefaultGenome]
 # node activation options
@@ -18,6 +19,7 @@ aggregation_options     = sum product max min maxabs median mean
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -33,9 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = 1
-enabled_mutate_rate     = 0.05
+enabled_default           = 1
+enabled_mutate_rate       = 0.05
 enabled_rate_to_false_add = 0.05
+enabled_rate_to_true_add  = 0.0
 
 feed_forward            = True
 initial_connection      = partial 0.5
@@ -52,6 +55,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0

--- a/tests/test_configuration4
+++ b/tests/test_configuration4
@@ -19,6 +19,7 @@ aggregation_options     = sum product max min maxabs median mean
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -34,9 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = random
-enabled_mutate_rate     = 0.05
-enabled_rate_to_true_add = 0.5
+enabled_default           = random
+enabled_mutate_rate       = 0.05
+enabled_rate_to_true_add  = 0.5
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = partial 0.5
@@ -53,6 +55,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0

--- a/tests/test_configuration5
+++ b/tests/test_configuration5
@@ -19,6 +19,7 @@ aggregation_options     = sum product max min maxabs median mean
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 1.0
+bias_init_type          = gaussian
 bias_max_value          = 30.0
 bias_min_value          = -30.0
 bias_mutate_power       = 0.5
@@ -34,9 +35,10 @@ conn_add_prob           = 0.5
 conn_delete_prob        = 0.5
 
 # connection enable options
-enabled_default         = no
-enabled_mutate_rate     = 0.05
-enabled_rate_to_true_add = 0.75
+enabled_default           = no
+enabled_mutate_rate       = 0.05
+enabled_rate_to_true_add  = 0.75
+enabled_rate_to_false_add = 0.0
 
 feed_forward            = True
 initial_connection      = partial 0.5
@@ -53,6 +55,7 @@ num_outputs             = 1
 # node response options
 response_init_mean      = 1.0
 response_init_stdev     = 0.0
+response_init_type      = gaussian
 response_max_value      = 30.0
 response_min_value      = -30.0
 response_mutate_power   = 0.0

--- a/tests/test_configuration_iznn
+++ b/tests/test_configuration_iznn
@@ -3,11 +3,13 @@ fitness_criterion     = max
 fitness_threshold     = 3.9
 pop_size              = 150
 reset_on_extinction   = False
+no_fitness_termination = False
 
 [IZGenome]
 # node bias options
 bias_init_mean          = 0.0
 bias_init_stdev         = 10.0
+bias_init_type          = gaussian
 bias_max_value          = 100.0
 bias_min_value          = -100.0
 bias_mutate_power       = 5.0
@@ -24,8 +26,10 @@ conn_add_prob           = 0.2
 conn_delete_prob        = 0.2
 
 # connection enable options
-enabled_default         = True
-enabled_mutate_rate     = 0.01
+enabled_default           = True
+enabled_mutate_rate       = 0.01
+enabled_rate_to_false_add = 0.0
+enabled_rate_to_true_add  = 0.0
 
 feed_forward            = False
 initial_connection      = full
@@ -42,6 +46,7 @@ num_outputs             = 2
 # node parameters for regular spiking
 a_init_mean      = 0.02
 a_init_stdev     = 0.0
+a_init_type      = gaussian
 a_max_value      = 30.0
 a_min_value      = -30.0
 a_mutate_power   = 0.0
@@ -50,6 +55,7 @@ a_replace_rate   = 0.0
 
 b_init_mean      = 0.2
 b_init_stdev     = 0.0
+b_init_type      = gaussian
 b_max_value      = 30.0
 b_min_value      = -30.0
 b_mutate_power   = 0.0
@@ -58,6 +64,7 @@ b_replace_rate   = 0.0
 
 c_init_mean      = -65.0
 c_init_stdev     = 0.0
+c_init_type      = gaussian
 c_max_value      = 30.0
 c_min_value      = -30.0
 c_mutate_power   = 0.0
@@ -66,15 +73,21 @@ c_replace_rate   = 0.0
 
 d_init_mean      = 8.0
 d_init_stdev     = 0.0
+d_init_type      = gaussian
 d_max_value      = 30.0
 d_min_value      = -30.0
 d_mutate_power   = 0.0
 d_mutate_rate    = 0.0
 d_replace_rate   = 0.0
 
+# structural mutation
+single_structural_mutation = False
+structural_mutation_surer = default
+
 # connection weight options
 weight_init_mean        = 0.0
 weight_init_stdev       = 3.0
+weight_init_type        = gaussian
 weight_max_value        = 100
 weight_min_value        = -100
 weight_mutate_power     = 2.0


### PR DESCRIPTION
Set all missing config values in test so we don't get the "default used" warnings